### PR TITLE
Update to first buy/sell interval logic

### DIFF
--- a/main.py
+++ b/main.py
@@ -16,17 +16,18 @@ def main():
     parser.add_argument("--pairs", nargs='+', required=True, help="List of cryptocurrency pairs to trade (e.g., BTCUSD ETHUSD SOLUSD)")
     args = parser.parse_args()
 
+    # Remove this line as it's no longer needed
+    # min_interval_percentage = args.grid_percentage * 0.75
+
     auth_builder = KrakenAuthBuilder(api_key=API_KEY, api_secret=API_SECRET)
     price_fetcher = CryptoPriceFetcher(auth_builder)
     market_analyzer = MarketAnalyzer(price_fetcher)
     position_tracker = PositionTracker()
-    order_manager = OrderManager(auth_builder, position_tracker, market_analyzer, price_fetcher, args.grid_percentage, config_file = 'config.json')
-
+    order_manager = OrderManager(auth_builder, position_tracker, market_analyzer, price_fetcher, args.grid_percentage, config_file='config.json')
     order_manager.load_open_orders()
 
     while True:
         order_manager.check_and_update_open_orders(args.pairs)
-
         for pair in args.pairs:
             best_price_info = price_fetcher.get_best_price(pair)
             if best_price_info:
@@ -34,13 +35,14 @@ def main():
                 order_manager.execute_grid_strategy(
                     current_price=current_price,
                     grid_percentage=args.grid_percentage,
+                    # Remove this parameter
+                    # min_interval_percentage=min_interval_percentage,
                     lower_bound_percentage=args.lower_bound_percentage,
                     pair=pair,
                     max_open_orders=args.max_open_orders
                 )
             else:
                 logging.error(f"Failed to fetch the current price for {pair}")
-        
         time.sleep(args.time_range)
 
 if __name__ == "__main__":

--- a/tests/test_orders.py
+++ b/tests/test_orders.py
@@ -21,26 +21,22 @@ class TestOrderManager(unittest.TestCase):
         self.market_analyzer = Mock(spec=MarketAnalyzer)
         self.price_fetcher = Mock(spec=CryptoPriceFetcher)
 
-        # Path to your actual config file
-        real_config_file = 'config.json'  
+        real_config_file = 'config.json'
 
- 
         self.temp_dir = tempfile.mkdtemp()
         self.test_log_file = os.path.join(self.temp_dir, 'test_bot_orders.json')
 
-        # Use the real config file here
         self.order_manager = OrderManager(
             self.auth_builder,
             self.position_tracker,
             self.market_analyzer,
             self.price_fetcher,
             grid_percentage=0.01,  # Set grid percentage for testing
-            config_file=real_config_file  # Use the real config file path
+            config_file=real_config_file
         )
         self.order_manager.log_file = self.test_log_file
 
     def tearDown(self):
-        # Remove the temporary directory and its contents after each test
         for root, dirs, files in os.walk(self.temp_dir, topdown=False):
             for name in files:
                 os.remove(os.path.join(root, name))
@@ -66,7 +62,6 @@ class TestOrderManager(unittest.TestCase):
         self.assertEqual(result['price'], 50000.0)
         self.assertEqual(result['volume'], 0.001)
 
-        # Check if the order was logged
         with open(self.test_log_file, 'r') as f:
             logged_orders = json.load(f)
         self.assertEqual(len(logged_orders), 1)
@@ -81,42 +76,121 @@ class TestOrderManager(unittest.TestCase):
         self.assertEqual(result, {})
         mock_post.assert_not_called()
 
-    def test_execute_grid_strategy(self):
+
+    def test_execute_grid_strategy_with_minimum_interval(self):
         self.order_manager._execute_buy_and_sell_orders = Mock()
         self.market_analyzer.update_price_history = Mock()
         self.market_analyzer.calculate_volatility = Mock(return_value=0.05)
 
+        current_price = 50000.0
+        grid_percentage = 0.01  # 1% grid
+        lower_bound_percentage = 0.05
+        max_open_orders = 5
+
         self.order_manager.execute_grid_strategy(
-            current_price=50000.0,
-            grid_percentage=0.01,
-            lower_bound_percentage=0.05,
+            current_price=current_price,
+            grid_percentage=grid_percentage,
+            lower_bound_percentage=lower_bound_percentage,
             pair="BTC/USD",
-            max_open_orders=5
+            max_open_orders=max_open_orders
         )
 
-        self.assertEqual(self.order_manager._execute_buy_and_sell_orders.call_count, 10)
+        initial_interval = current_price * (grid_percentage / 2)
+        grid_interval = current_price * grid_percentage
+        lower_bound = current_price * (1 - lower_bound_percentage)
+        upper_bound = current_price * (1 + lower_bound_percentage)
 
-    def test_check_and_update_open_orders(self):
-        self.order_manager.check_order_status = Mock(side_effect=[True, False, True])
+        expected_buy_orders = 0
+        expected_sell_orders = 0
+        buy_price = current_price - initial_interval
+        sell_price = current_price + initial_interval
 
-        self.order_manager.open_buy_orders = {
-            "BTC/USD": [
-                {"order_id": "123", "pair": "BTC/USD", "side": "buy"},
-                {"order_id": "456", "pair": "BTC/USD", "side": "buy"}
-            ]
-        }
-        self.order_manager.open_sell_orders = {
-            "BTC/USD": [
-                {"order_id": "789", "pair": "BTC/USD", "side": "sell"}
-            ]
-        }
+        # Calculate the number of expected buy orders
+        while buy_price > lower_bound and expected_buy_orders < max_open_orders:
+            expected_buy_orders += 1
+            buy_price -= grid_interval
 
-        self.order_manager.check_and_update_open_orders(["BTC/USD"])
+        # Calculate the number of expected sell orders
+        while sell_price < upper_bound and expected_sell_orders < max_open_orders:
+            expected_sell_orders += 1
+            sell_price += grid_interval
 
-        self.assertEqual(len(self.order_manager.open_buy_orders["BTC/USD"]), 1)
-        self.assertEqual(len(self.order_manager.open_sell_orders["BTC/USD"]), 1)
-        self.assertEqual(self.order_manager.open_buy_orders["BTC/USD"][0]["order_id"], "123")
-        self.assertEqual(self.order_manager.open_sell_orders["BTC/USD"][0]["order_id"], "789")
+        total_expected_orders = expected_buy_orders + expected_sell_orders
+        self.assertEqual(self.order_manager._execute_buy_and_sell_orders.call_count, total_expected_orders)
+
+        # Verify the prices of the orders
+        call_args_list = self.order_manager._execute_buy_and_sell_orders.call_args_list
+        buy_price = current_price - initial_interval
+        sell_price = current_price + initial_interval
+
+        for i, call_args in enumerate(call_args_list):
+            args, kwargs = call_args
+            price = args[0]  # Unpack the price from the args tuple
+            if kwargs['place_buy']:
+                self.assertAlmostEqual(price, buy_price, delta=0.01)
+                buy_price -= grid_interval
+            else:
+                self.assertAlmostEqual(price, sell_price, delta=0.01)
+                sell_price += grid_interval
+
+
+
+    @patch('requests.post')
+    def test_execute_grid_strategy_with_minimum_threshold(self, mock_post):
+        self.order_manager._execute_buy_and_sell_orders = Mock()
+        self.market_analyzer.update_price_history = Mock()
+        self.market_analyzer.calculate_volatility = Mock(return_value=0.01)  # Low volatility
+
+        current_price = 50000.0
+        grid_percentage = 0.01  # 1% grid
+        lower_bound_percentage = 0.05
+        max_open_orders = 5
+
+        self.order_manager.execute_grid_strategy(
+            current_price=current_price,
+            grid_percentage=grid_percentage,
+            lower_bound_percentage=lower_bound_percentage,
+            pair="BTC/USD",
+            max_open_orders=max_open_orders
+        )
+
+        initial_interval = current_price * (grid_percentage / 2)
+        grid_interval = current_price * grid_percentage
+        lower_bound = current_price * (1 - lower_bound_percentage)
+        upper_bound = current_price * (1 + lower_bound_percentage)
+
+        expected_buy_orders = 0
+        expected_sell_orders = 0
+        buy_price = current_price - initial_interval
+        sell_price = current_price + initial_interval
+
+        # Calculate the number of expected buy orders
+        while buy_price > lower_bound and expected_buy_orders < max_open_orders:
+            expected_buy_orders += 1
+            buy_price -= grid_interval
+
+        # Calculate the number of expected sell orders
+        while sell_price < upper_bound and expected_sell_orders < max_open_orders:
+            expected_sell_orders += 1
+            sell_price += grid_interval
+
+        total_expected_orders = expected_buy_orders + expected_sell_orders
+        self.assertEqual(self.order_manager._execute_buy_and_sell_orders.call_count, total_expected_orders)
+
+        # Verify the prices of the orders
+        call_args_list = self.order_manager._execute_buy_and_sell_orders.call_args_list
+        buy_price = current_price - initial_interval
+        sell_price = current_price + initial_interval
+
+        for i, call_args in enumerate(call_args_list):
+            args, kwargs = call_args
+            price = args[0]  # Unpack the price from the args tuple
+            if kwargs['place_buy']:
+                self.assertAlmostEqual(price, buy_price, delta=0.01)
+                buy_price -= grid_interval
+            else:
+                self.assertAlmostEqual(price, sell_price, delta=0.01)
+                sell_price += grid_interval
 
     def test_load_open_orders(self):
         test_orders = [
@@ -222,7 +296,6 @@ class TestOrderManager(unittest.TestCase):
         self.assertEqual(result['price'], 50000.0)
         self.assertEqual(result['volume'], 0.001)
 
-        # Check if the order was logged
         with open(self.test_log_file, 'r') as f:
             logged_orders = json.load(f)
         self.assertEqual(len(logged_orders), 1)
@@ -237,125 +310,32 @@ class TestOrderManager(unittest.TestCase):
         self.assertEqual(result, {})
         mock_post.assert_not_called()
 
-    def test_execute_grid_strategy(self):
+
+    @patch('requests.post')
+    def test_no_orders_below_lower_bound_or_above_upper_bound(self, mock_post):
         self.order_manager._execute_buy_and_sell_orders = Mock()
         self.market_analyzer.update_price_history = Mock()
         self.market_analyzer.calculate_volatility = Mock(return_value=0.05)
 
+        current_price = 50000.0
+        grid_percentage = 0.01
+        lower_bound_percentage = 0.05
+        max_open_orders = 5
+
         self.order_manager.execute_grid_strategy(
-            current_price=50000.0,
-            grid_percentage=0.01,
-            lower_bound_percentage=0.05,
+            current_price=current_price,
+            grid_percentage=grid_percentage,
+            lower_bound_percentage=lower_bound_percentage,
             pair="BTC/USD",
-            max_open_orders=5
+            max_open_orders=max_open_orders
         )
 
-        self.assertEqual(self.order_manager._execute_buy_and_sell_orders.call_count, 10)
+        lower_bound = current_price * (1 - lower_bound_percentage)
+        upper_bound = current_price * (1 + lower_bound_percentage)
 
-    def test_check_and_update_open_orders(self):
-        self.order_manager.check_order_status = Mock(side_effect=[True, False, True])
-
-        self.order_manager.open_buy_orders = {
-            "BTC/USD": [
-                {"order_id": "123", "pair": "BTC/USD", "side": "buy"},
-                {"order_id": "456", "pair": "BTC/USD", "side": "buy"}
-            ]
-        }
-        self.order_manager.open_sell_orders = {
-            "BTC/USD": [
-                {"order_id": "789", "pair": "BTC/USD", "side": "sell"}
-            ]
-        }
-
-        self.order_manager.check_and_update_open_orders(["BTC/USD"])
-
-        self.assertEqual(len(self.order_manager.open_buy_orders["BTC/USD"]), 1)
-        self.assertEqual(len(self.order_manager.open_sell_orders["BTC/USD"]), 1)
-        self.assertEqual(self.order_manager.open_buy_orders["BTC/USD"][0]["order_id"], "123")
-        self.assertEqual(self.order_manager.open_sell_orders["BTC/USD"][0]["order_id"], "789")
-
-    def test_load_open_orders(self):
-        test_orders = [
-            {"pair": "BTC/USD", "order_id": "123", "side": "buy"},
-            {"pair": "ETH/USD", "order_id": "456", "side": "sell"}
-        ]
-        with open(self.test_log_file, 'w') as f:
-            json.dump(test_orders, f)
-
-        self.order_manager.check_order_status = Mock(return_value=True)
-
-        self.order_manager.load_open_orders()
-
-        self.assertEqual(len(self.order_manager.open_buy_orders["BTC/USD"]), 1)
-        self.assertEqual(len(self.order_manager.open_sell_orders["ETH/USD"]), 1)
-        self.assertEqual(self.order_manager.open_buy_orders["BTC/USD"][0]["order_id"], "123")
-        self.assertEqual(self.order_manager.open_sell_orders["ETH/USD"][0]["order_id"], "456")
-
-    def test_round_price(self):
-        self.assertEqual(self.order_manager._round_price("BTC/USD", 50000.123), 50000.1)
-        self.assertEqual(self.order_manager._round_price("ETH/USD", 3000.5678), 3000.57)
-        self.assertEqual(self.order_manager._round_price("XRP/USD", 0.54321), 0.5432)
-
-    def test_round_volume(self):
-        self.assertEqual(self.order_manager._round_volume("BTC/USD", 1.23456789), 1.2346)
-        self.assertEqual(self.order_manager._round_volume("ETH/USD", 5.6789), 5.6789)
-        self.assertEqual(self.order_manager._round_volume("XRP/USD", 100.5), 100)
-
-    def test_get_min_trade_size(self):
-        self.assertEqual(self.order_manager._get_min_trade_size("BTC/USD"), 0.0002)
-        self.assertEqual(self.order_manager._get_min_trade_size("ETH/USD"), 0.002)
-        self.assertEqual(self.order_manager._get_min_trade_size("XRP/USD"), 10.0)
-        self.assertEqual(self.order_manager._get_min_trade_size("UNKNOWN/USD"), 0.0001)
-
-    @patch('requests.post')
-    def test_check_order_status(self, mock_post):
-        mock_response = Mock()
-        mock_response.json.return_value = {
-            'result': {
-                'OABC123': {
-                    'status': 'open'
-                }
-            }
-        }
-        mock_response.raise_for_status.return_value = None
-        mock_post.return_value = mock_response
-
-        result = self.order_manager.check_order_status('OABC123')
-        self.assertTrue(result)
-
-        mock_response.json.return_value = {
-            'result': {
-                'OABC123': {
-                    'status': 'closed'
-                }
-            }
-        }
-        result = self.order_manager.check_order_status('OABC123')
-        self.assertFalse(result)
-
-    def test_log_order(self):
-        order_details = {
-            "order_id": "TEST123",
-            "side": "buy",
-            "pair": "BTC/USD",
-            "price": 50000.0,
-            "volume": 0.1
-        }
-        self.order_manager.log_order(order_details)
-
-        with open(self.test_log_file, 'r') as f:
-            logged_orders = json.load(f)
-        
-        self.assertEqual(len(logged_orders), 1)
-        self.assertEqual(logged_orders[0], order_details)
-
-    def test_log_order_missing_order_id(self):
-        order_details = {
-            "side": "buy",
-            "pair": "BTC/USD",
-            "price": 50000.0,
-            "volume": 0.1
-        }
-        self.order_manager.log_order(order_details)
-
-        self.assertFalse(os.path.exists(self.test_log_file))
+        for call_args in self.order_manager._execute_buy_and_sell_orders.call_args_list:
+            price = call_args[0][0]
+            if call_args[1]['place_buy']:
+                self.assertGreaterEqual(price, lower_bound)
+            else:
+                self.assertLessEqual(price, upper_bound)


### PR DESCRIPTION
Updated first buy/sell pair to meet min threshold set by grid_percentage input from user. expanding ability to capture small profits while still maintaining overall profitability based on fee structure